### PR TITLE
Fix prod migrations

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:17-alpine
     container_name: criterium-postgres
     env_file:
-      - .env.production
+      - apps/api/.env.production
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
@@ -28,7 +28,7 @@ services:
     image: ghcr.io/mdportnov/criterium-edu-backend:latest
     container_name: criterium-edu-backend
     env_file:
-      - .env.production
+      - apps/api/.env.production
     environment:
       NODE_ENV: ${NODE_ENV:-production}
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-criterium}
@@ -46,7 +46,7 @@ services:
     image: ghcr.io/mdportnov/criterium-edu-frontend:latest
     container_name: criterium-edu-frontend
     env_file:
-      - .env.production
+      - apps/web-ui/.env.production
     ports:
       - "80:80"
     restart: always

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,7 @@
   "sourceRoot": "apps/api/src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
+    "webpack": false,
     "tsConfigPath": "apps/api/tsconfig.app.json"
   },
   "monorepo": true,


### PR DESCRIPTION
## Summary
- disable webpack bundling so NestJS keeps migration files in dist
- reference correct env files in production compose setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68427f084300832a806ee2b5964bfe84