### PR TITLE
Fix loginAsDto userId validator

### DIFF
--- a/libs/shared/src/dto/auth.dto.ts
+++ b/libs/shared/src/dto/auth.dto.ts
@@ -1,8 +1,8 @@
 import {
   IsEmail,
   IsNotEmpty,
-  IsNumber,
   IsString,
+  IsUUID,
   MinLength,
 } from 'class-validator';
 
@@ -41,7 +41,7 @@ export class TokenDto {
 }
 
 export class LoginAsDto {
-  @IsNumber()
+  @IsUUID()
   @IsNotEmpty()
   userId: string;
 }


### PR DESCRIPTION
## Summary
- enforce UUID validator on `userId` in `LoginAsDto`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684290872bc8832a9dfd9f2db0ce1928